### PR TITLE
Missed injector property bug

### DIFF
--- a/Source/JSObjectionInjector.m
+++ b/Source/JSObjectionInjector.m
@@ -110,6 +110,7 @@
                 [_context setObject:injectorEntry forKey:key];              
             } else if(isClass) {
                 injectorEntry = [[[JSObjectionInjectorEntry alloc] initWithClass:classOrProtocol lifeCycle:JSObjectionInstantiationRuleNormal] autorelease];
+                injectorEntry.injector = self;
                 [_context setObject:injectorEntry forKey:key];
             }
         }


### PR DESCRIPTION
Hi, I think I found a bug.

With injector property not defined app crashed if one of the required property is metaclass-protocol binding.

Debugging show that instance of my class creating without `injector` property and later it's skipped line `id theObject = [injector getObject:desiredClassOrProtocol];` in `JSObjectionUtils.m`. After that app crashed.
