### PR TITLE
Fixed retain cycle in injector

### DIFF
--- a/Source/JSObjectionInjector.m
+++ b/Source/JSObjectionInjector.m
@@ -17,7 +17,7 @@
 
 - (id)initWithInjector:(JSObjectionInjector *)injector {
     if ((self = [super init])) {
-        _injector = [injector retain];
+        _injector = injector;
     }
     return self;
 }
@@ -26,10 +26,6 @@
     [self bind:[[[JSObjectFactory alloc] initWithInjector:_injector] autorelease] toClass:[JSObjectFactory class]];
 }
 
-- (void)dealloc {
-    [_injector release];
-    [super dealloc];
-}
 @end
   
 @interface JSObjectionInjector(Private)


### PR DESCRIPTION
Hey! 
I'm using Objection in a complex setup which involves switching injectors. I noticed then that something was preventing injectors from being deallocated. I did a little research and found a retain cycle. __JSObjectionInjectorDefaultModule is retaining an injector, while it itself is stored inside the injector in _modules array. 
Cheers :)
