### PR TITLE
Fixed an issue where a class is dependency injected with a nil value object

### DIFF
--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -131,6 +131,10 @@ static void InjectDependenciesIntoProperties(JSObjectionInjector *injector, Clas
                                              userInfo:nil];
             }
             
+            if (theObject == nil) {
+                theObject = [NSNull null];
+            }
+            
             [propertiesDictionary setObject:theObject forKey:propertyName];
         }
         

--- a/Specs/Fixtures.h
+++ b/Specs/Fixtures.h
@@ -41,6 +41,8 @@
 @interface FiveSpeedCar : Car<ManualCar>
 @end
 
+@interface SixSpeedCar : Car<ManualCar>
+@end
 
 @interface CarFactory : NSObject
 {

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -41,6 +41,11 @@ objection_register(FiveSpeedCar)
 objection_requires(@"gearBox")
 @end
 
+@implementation SixSpeedCar
+objection_register(SixSpeedCar)
+
+@end
+
 @implementation CarFactory
 objection_register_singleton(CarFactory)
 @end

--- a/Specs/ModuleFixtures.h
+++ b/Specs/ModuleFixtures.h
@@ -53,6 +53,9 @@ extern BOOL gEagerSingletonHook;
 @end
 
 @interface BlockModule : JSObjectionModule
+
+@property (nonatomic, assign) BOOL instrumentNilBlock;
+
 @end
 
 @interface CreditCardValidator : NSObject

--- a/Specs/ModuleFixtures.m
+++ b/Specs/ModuleFixtures.m
@@ -101,11 +101,26 @@ objection_register_singleton(EagerSingleton)
 - (void)configure
 {
     NSString *myEngine = @"My Engine";
-
+    Brakes *myBrakes = [[Brakes alloc] init];
+    
     [self bindBlock:^(JSObjectionInjector *context) {
-        Car *car = [context getObject:[FiveSpeedCar class]];
-        car.engine = (id)myEngine;
-        return (id)car;    
+        if (_instrumentNilBlock) {
+            return (id)nil;
+        }
+        
+        return (id)myBrakes;
+    } toClass:[Brakes class]];
+    
+    [self bindBlock:^(JSObjectionInjector *context) {
+        Car *car = nil;
+        if (_instrumentNilBlock) {
+            car = [context getObject:[SixSpeedCar class]];            
+        }
+        else {
+            car = [context getObject:[FiveSpeedCar class]];
+            car.engine = (id)myEngine;
+        }
+        return (id)car;
     } toClass:[Car class]];
 
     AfterMarketGearBox *gearBox = [[[AfterMarketGearBox alloc] init] autorelease];

--- a/Specs/ModuleUsageSpecs.m
+++ b/Specs/ModuleUsageSpecs.m
@@ -98,7 +98,28 @@ describe(@"block bindings", ^{
   it(@"allows a bound class to be created using a block", ^{
     AfterMarketGearBox *gearBox = [[JSObjection defaultInjector] getObject:@protocol(GearBox)];      
     assertThat(gearBox, is(instanceOf([AfterMarketGearBox class])));
-  });    
+  });
+});
+
+describe(@"block bindings properties nil", ^{
+    __block BlockModule *blockModule = nil;
+    
+    beforeEach(^{
+        blockModule = [[[BlockModule alloc] init] autorelease];
+        blockModule.instrumentNilBlock = YES;
+        JSObjectionInjector *injector = [JSObjection createInjector:blockModule];
+        [JSObjection setDefaultInjector:injector];
+    });
+    
+    it(@"allows a returned nil value from bindBlock", ^{
+        // attempt to inject dependencies into Car via InjectDependenciesIntoProperties
+        // ensure that Car is successfully dependency injected and property brakes
+        // returned from bindBlock is set as nil on Car if that was the intention
+        Car *car = [[JSObjection defaultInjector] getObject:[Car class]];
+        assertThat(car, notNilValue());
+        assertThat(car, is(instanceOf([SixSpeedCar class])));
+        assertThat(car.brakes, nilValue());
+    });
 });
 
 describe(@"meta class bindings", ^{


### PR DESCRIPTION
This specifically pertains to bindBlock otherwise an exception setObjectForKey: object cannot be nil (key: propertyNameToBeInjected) is returned due to the propertiesDictionary in use. Added tests for testing that a class dependency injected with a property using objection_requires can be set to nil.
