### PR TITLE
Added objection_requires macro that takes in a list of selectors

### DIFF
--- a/Source/Objection.h
+++ b/Source/Objection.h
@@ -33,6 +33,17 @@
         return JSObjectionUtils.buildDependenciesForClass(self, requirements); \
     }
 
+#define objection_requires_sel(args...) \
+    + (NSSet *)objectionRequires { \
+        SEL selectors[] = {args}; \
+        NSMutableSet *requirements = [NSMutableSet set]; \
+        for (int j = 0; j < sizeof(selectors)/ sizeof(SEL); j++) { \
+            SEL selector = selectors[j]; \
+            [requirements addObject:NSStringFromSelector(selector)]; \
+        } \
+    return JSObjectionUtils.buildDependenciesForClass(self, requirements); \
+    }
+
 #define objection_initializer(selectorSymbol, args...) \
     + (NSDictionary *)objectionInitializer { \
         id objs[]= {args}; \

--- a/Specs/BasicUsageSpecs.m
+++ b/Specs/BasicUsageSpecs.m
@@ -1,5 +1,4 @@
 #import "SpecHelper.h"
-#import <objc/runtime.h>
 #import "Fixtures.h"
 #import "InitializerFixtures.h"
 
@@ -31,6 +30,12 @@ it(@"correctly builds and object with dependencies", ^{
 
     assertThat(car.brakes, isNot(nilValue()));
     assertThat(car.brakes, is(instanceOf([Brakes class])));
+});
+
+it(@"correctly builds objects with selector dependencies", ^{
+    UnstoppableCar *car = [[JSObjection defaultInjector] getObject:[UnstoppableCar class]];
+
+    assertThat(car.engine, is(instanceOf([Engine class])));
 });
 
 it(@"will inject dependencies into properties of an existing instance", ^{
@@ -124,7 +129,6 @@ describe(@"object factory", ^{
         [[car.model should] equal:@"Model"];
         [[car.horsePower should] equal:@"Power"];
         [[car.year should] equal:@"Year"];
-        
     });
 });
 

--- a/Specs/Fixtures.h
+++ b/Specs/Fixtures.h
@@ -81,3 +81,7 @@
 @property(nonatomic, strong) SingletonBar *bar;
 
 @end
+
+@interface UnstoppableCar : NSObject
+@property(nonatomic, strong) Engine *engine;
+@end

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -73,3 +73,7 @@ objection_requires(@"bar")
 
 @synthesize bar;
 @end
+
+@implementation UnstoppableCar
+objection_requires_sel(@selector(engine))
+@end


### PR DESCRIPTION
Defining requirements as strings bears the risk of forgetting to change the string after renaming property. Defining requirements as selectors decreases risk of such problem as compiler throws an error when it does not see a matching selector defined anywhere. 

Moreover using selectors rather than strings to define requirements makes it easier for other IDEs (like AppCode) to perform refactors. 

I have one question regarding style in specs: I've noticed that most of them are missing top describe block. Usually the block is defined to describe object being tested. I understand that the purpose of specs in this project is more to test behavior of whole framework, rather than single objects and that this is the reason for such structure, correct?
