### PR TITLE
Updated read me with info for new objection_require_sel 

### DIFF
--- a/Objection.podspec
+++ b/Objection.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name         = 'Objection'
-  s.version      = '1.0.0'
+  s.version      = '1.0.1'
   s.summary      = 'A lightweight dependency injection framework for Objective-C.'
   s.author       = { 'Justin DeWind' => 'dewind@atomicobject.com' }
-  s.source       = { :git => 'https://github.com/atomicobject/objection.git', :tag => '1.0.0' }
+  s.source       = { :git => 'https://github.com/atomicobject/objection.git', :tag => "#{s.version}" }
   s.homepage     = 'http://www.objection-framework.org'
   s.source_files = 'Source'
   s.license      = "https://github.com/atomicobject/objection/blob/master/LICENSE"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ objection_requires(@"engine", @"brakes")
 @synthesize engine, brakes, awake;
 @end
 ```
+#### Defining dependencies with selectors
+
+You can alternatively use selectors to define dependencies. This is a more convenient way as it will generate a warning if a given selector is not visible in current scope. 
+
+#### Example
+
+```objective-c
+@implementation Car
+objection_requires_sel(@selector(engine), @selector(brakes))
+@synthesize engine, brakes, awake;
+@end
+```
+
 ### Fetching Objects from Objection
 
 An object can be fetched from objection by creating an injector and then asking for an instance of a particular class or protocol. An injector manages its own object context. Which means that a singleton is per injector and is not necessarily a *true* singleton.


### PR DESCRIPTION
I've updated the readme file so that it contains a description about new objection_requires_sel. 

I've also updated podspec file and changed the way it looks for a given version Instead of specifically defining tag it now takes previously defined version - one less parameter to worry about ;)

Could you release a new pod version in the main pods repository? I'm really eager to use the new feature! 

Thanks!
