### PR TITLE
Added possibility to manage injector's modules on the fly.

### DIFF
--- a/Source/JSObjectionInjector.h
+++ b/Source/JSObjectionInjector.h
@@ -21,6 +21,13 @@
 - (id)withoutModuleOfType:(Class)moduleClass;
 - (id)withoutModuleOfTypes:(Class)first, ... NS_REQUIRES_NIL_TERMINATION;
 - (id)withoutModuleCollection:(NSArray *)moduleClasses;
+- (void)appendModule:(JSObjectionModule *)module;
+- (void)appendModules:(JSObjectionModule *)first, ... NS_REQUIRES_NIL_TERMINATION;
+- (void)appendModuleCollection:(NSArray *)modules;
+- (void)removeModule:(JSObjectionModule *)module;
+- (void)removeModules:(NSArray *)modules;
+- (void)removeModuleOfType:(Class)moduleClass;
+- (void)removeModuleOfTypes:(Class)first, ...;
 - (void)injectDependencies:(id)object;
 - (id)objectForKeyedSubscript: (id)key;
 @end

--- a/Specs/AddAndRemoveModulesSpecs.m
+++ b/Specs/AddAndRemoveModulesSpecs.m
@@ -15,9 +15,9 @@ beforeEach(^{
 
 it(@"builds a new injector with new modules", ^{
     assertThat([injector getObject:@protocol(GearBox)], is(instanceOf([AfterMarketGearBox class])));
-    assertThat([injector getObject:[Car class]], isNot(instanceOf([FiveSpeedCar class])));    
+    assertThat([injector getObject:[Car class]], isNot(instanceOf([FiveSpeedCar class])));
     assertThatBool(gEagerSingletonHook, equalToBool(NO));
-    
+
     injector = [injector withModules:
                     [[ProviderModule alloc] init],
                     [[FirstModule alloc] init], nil];
@@ -35,7 +35,36 @@ it(@"builds a new module without the module types", ^{
     assertThat([injector getObject:[Car class]], is(instanceOf([FiveSpeedCar class])));
 
     injector = [injector withoutModuleOfTypes:[SecondModule class], [ProviderModule class], nil];
-    
+
+    assertThat([injector getObject:@protocol(GearBox)], is(nilValue()));
+    assertThat([injector getObject:[Car class]], isNot(instanceOf([FiveSpeedCar class])));
+});
+
+it(@"builds a new injector and appends new modules ", ^{
+    assertThat([injector getObject:@protocol(GearBox)], is(instanceOf([AfterMarketGearBox class])));
+    assertThat([injector getObject:[Car class]], isNot(instanceOf([FiveSpeedCar class])));
+    assertThatBool(gEagerSingletonHook, equalToBool(NO));
+
+    [injector appendModules:
+            [[ProviderModule alloc] init],
+            [[FirstModule alloc] init], nil];
+
+    assertThat([injector getObject:@protocol(GearBox)], is(instanceOf([AfterMarketGearBox class])));
+    assertThat([injector getObject:[Car class]], is(instanceOf([FiveSpeedCar class])));
+    assertThatBool(gEagerSingletonHook, equalToBool(YES));
+});
+
+it(@"builds a new injector and removes modules", ^{
+    injector = [injector withModules:
+            [[FirstModule alloc] init],
+            [[SecondModule alloc] init],
+            [[ProviderModule alloc] init], nil];
+
+    assertThat([injector getObject:@protocol(GearBox)], is(instanceOf([AfterMarketGearBox class])));
+    assertThat([injector getObject:[Car class]], is(instanceOf([FiveSpeedCar class])));
+
+    [injector removeModuleOfTypes:[SecondModule class], [ProviderModule class], nil];
+
     assertThat([injector getObject:@protocol(GearBox)], is(nilValue()));
     assertThat([injector getObject:[Car class]], isNot(instanceOf([FiveSpeedCar class])));
 });

--- a/Vendor/Kiwi/Kiwi.xcodeproj/project.pbxproj
+++ b/Vendor/Kiwi/Kiwi.xcodeproj/project.pbxproj
@@ -72,7 +72,6 @@
 		44FC0E9516B6377D0050D616 /* KWGenericMatchingAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C8A16A802920030A0B1 /* KWGenericMatchingAdditions.h */; };
 		44FC0E9616B6377D0050D616 /* KWHaveMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C8C16A802920030A0B1 /* KWHaveMatcher.h */; };
 		44FC0E9716B6377D0050D616 /* KWHaveValueMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C8E16A802920030A0B1 /* KWHaveValueMatcher.h */; };
-		44FC0E9816B6377D0050D616 /* (null) in CopyFiles */ = {isa = PBXBuildFile; };
 		44FC0E9916B6377D0050D616 /* KWInequalityMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C9116A802920030A0B1 /* KWInequalityMatcher.h */; };
 		44FC0E9A16B6377D0050D616 /* KWIntercept.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C9316A802920030A0B1 /* KWIntercept.h */; };
 		44FC0E9B16B6377D0050D616 /* KWInvocationCapturer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982C9516A802920030A0B1 /* KWInvocationCapturer.h */; };
@@ -568,7 +567,6 @@
 				44FC0E9516B6377D0050D616 /* KWGenericMatchingAdditions.h in CopyFiles */,
 				44FC0E9616B6377D0050D616 /* KWHaveMatcher.h in CopyFiles */,
 				44FC0E9716B6377D0050D616 /* KWHaveValueMatcher.h in CopyFiles */,
-				44FC0E9816B6377D0050D616 /* (null) in CopyFiles */,
 				44FC0E9916B6377D0050D616 /* KWInequalityMatcher.h in CopyFiles */,
 				44FC0E9A16B6377D0050D616 /* KWIntercept.h in CopyFiles */,
 				44FC0E9B16B6377D0050D616 /* KWInvocationCapturer.h in CopyFiles */,


### PR DESCRIPTION
I have added simple API to manage injector's modules list during its lifetime. They are being reconfigured on append action and deregistered on remove. My motivation: standard with(out)Module\* API always creates a new object which results in re-creation of all objects (singletons). Appending/removing on the fly solves this issue.
I've found it really useful.
