### PR TITLE
Objects are also notified when dependencies are injected manually

### DIFF
--- a/Source/JSObjectionInjectorEntry.m
+++ b/Source/JSObjectionInjectorEntry.m
@@ -46,12 +46,6 @@
 #pragma mark -
 #pragma mark Private Methods
 
-- (void)notifyObjectThatItIsReady:(id)object {
-  if([object respondsToSelector:@selector(awakeFromObjection)]) {
-    [object performSelector:@selector(awakeFromObjection)];
-  }
-}
-
 - (id)buildObject:(NSArray *)arguments {
     
     id objectUnderConstruction = nil;
@@ -66,8 +60,7 @@
     }
     
     JSObjectionUtils.injectDependenciesIntoProperties(self.injector, self.classEntry, objectUnderConstruction);
-
-    [self notifyObjectThatItIsReady: objectUnderConstruction];
+    
     return objectUnderConstruction;
 }
 

--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -133,6 +133,10 @@ static void InjectDependenciesIntoProperties(JSObjectionInjector *injector, Clas
         
         [object setValuesForKeysWithDictionary:propertiesDictionary];
     }
+    
+    if ([object respondsToSelector:@selector(awakeFromObjection)]) {
+        [object performSelector:@selector(awakeFromObjection)];
+    }
 }
 
 const struct JSObjectionUtils JSObjectionUtils = {

--- a/Specs/BasicUsageSpecs.m
+++ b/Specs/BasicUsageSpecs.m
@@ -53,6 +53,15 @@ it(@"will inject dependencies into properties of an existing instance", ^{
     assertThat(car.brakes, is(instanceOf([Brakes class])));
 });
 
+it(@"calls awakeFromObjection when injecting dependencies into properties of an existing instance", ^{
+    Car *car = [[Car alloc] init];
+    
+    [[JSObjection defaultInjector] injectDependencies:car];
+
+    assertThatBool([car awake], equalToBool(YES));
+    assertThatBool([car.engine awake], equalToBool(YES));
+});
+
 it(@"defaults to returning a new instance", ^{
       id thomas = [[JSObjection defaultInjector] getObject:[Engine class]];
       id gordan = [[JSObjection defaultInjector] getObject:[Engine class]];


### PR DESCRIPTION
This behavior was inconsistent when using `- [JSObjectionInjector injectDependencies:]` instead of `- [JSObjectionInjector getObject:]`.
