### PR TITLE
Ability to specify a class method as an objection_initializer

### DIFF
--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -85,11 +85,17 @@ static objc_property_t GetProperty(Class klass, NSString *propertyName) {
 
 
 static id BuildObjectWithInitializer(Class klass, SEL initializer, NSArray *arguments) {
-    id instance = [klass alloc];
-    NSMethodSignature *signature = [klass instanceMethodSignatureForSelector:initializer];
+	// is it a static method
+	NSMethodSignature *signature = [klass methodSignatureForSelector:initializer];
+	BOOL isStaticMethod = (signature != nil);
+	__autoreleasing id instance = nil;
+	if (!isStaticMethod) {
+		instance = [klass alloc];
+		signature = [klass instanceMethodSignatureForSelector:initializer];
+	}
     if (signature) {
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-        [invocation setTarget:instance];
+        [invocation setTarget:isStaticMethod ? klass : instance];
         [invocation setSelector:initializer];
         for (int i = 0; i < arguments.count; i++) {
             __unsafe_unretained id argument = [arguments objectAtIndex:i];


### PR DESCRIPTION
I implemented ability to have a class method as `objection_initializer`. Also this pull request contains couple of changes that I would love to hear someone's opinions on.
1. I added an explicit `__autoreleasing` ARC qualifier for the returning instance since ARC was getting sometimes.
2. `objection_initializer`'s method result is being stored in the returning `instance` variable. This one was also aimed to fix an edge-case when initialization method wouldn't return the same instance as `alloc` (which is obviously is not a recommended practice). Also it address all cases when a static factory method is used.

Please let me know if approach I used seems valid to you. 

Thank you.
