### PR TITLE
Engine fixture: setting objection_initializer to init

### DIFF
--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -87,9 +87,9 @@ static objc_property_t GetProperty(Class klass, NSString *propertyName) {
 static id BuildObjectWithInitializer(Class klass, SEL initializer, NSArray *arguments) {
 	NSMethodSignature *signature = [klass methodSignatureForSelector:initializer];
 	id instance = nil;
-    BOOL isStatic = signature != nil;
+    BOOL isStatic = (initializer != @selector(init) && (signature != nil));
     
-	if (!signature) {
+	if (!isStatic) {
 		instance = [klass alloc];
 		signature = [klass instanceMethodSignatureForSelector:initializer];
 	}

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -8,7 +8,7 @@ objection_initializer(init)
 
 @synthesize awake;
 
-- (void) awakeFromObjection {
+- (void)awakeFromObjection {
 	awake = YES;  
 }
 @end

--- a/Specs/InitializerFixtures.m
+++ b/Specs/InitializerFixtures.m
@@ -5,7 +5,6 @@ objection_register(Truck)
 objection_initializer(truck:, @"Chevy")
 
 + (id)truck: (NSString *)name {
-    NSLog(@"TRUCK!");
     Truck *truck = [[self alloc] init];
     truck.name = name;
     return truck;    


### PR DESCRIPTION
This exposes a bug introduced in #61. Setting `objection_initializer` to init makes [this](https://github.com/atomicobject/objection/pull/61/files#diff-373563787695b5a838da5167c6823705R89) return the instance method, not a class method.
