### PR TITLE
Added ability to unbind registered classes and protocols

### DIFF
--- a/Source/JSObjectionModule.h
+++ b/Source/JSObjectionModule.h
@@ -30,6 +30,8 @@
 - (void)bindBlock:(id (^)(JSObjectionInjector *context))block toClass:(Class)aClass inScope:(JSObjectionScope)scope;
 - (void)bindBlock:(id (^)(JSObjectionInjector *context))block toProtocol:(Protocol *)aProtocol inScope:(JSObjectionScope)scope;
 - (void)bindClass:(Class)aClass inScope:(JSObjectionScope)scope;
+- (void)unbindClass:(Class)aClass;
+- (void)unbindProtocol:(Protocol *)aProtocol;
 - (void)registerEagerSingleton:(Class)aClass;
 - (BOOL)hasBindingForClass:(Class)aClass;
 - (BOOL)hasBindingForProtocol:(Protocol *)protocol;

--- a/Source/JSObjectionModule.m
+++ b/Source/JSObjectionModule.m
@@ -136,6 +136,16 @@
   return [_bindings objectForKey:[self protocolKey:protocol]] != nil;
 }
 
+- (void)unbindClass:(Class)aClass {
+    id key = NSStringFromClass(aClass);
+    [_bindings removeObjectForKey:key];
+}
+
+- (void)unbindProtocol:(Protocol *)aProtocol {
+    id key = [self protocolKey:aProtocol];
+    [_bindings removeObjectForKey:key];
+}
+
 - (void) configure {
 }
 

--- a/Specs/ModuleUsageSpecs.m
+++ b/Specs/ModuleUsageSpecs.m
@@ -261,4 +261,27 @@ describe(@"has binding", ^{
 
 });
 
+describe(@"supports unbinding", ^{
+    __block JSObjectionModule *module;
+    beforeEach(^{
+        module = [[JSObjectionModule alloc] init];
+    });
+    
+    it(@"supports class unbinding", ^{
+        id instance = [[NSObject alloc] init];
+        [module bind:instance toClass:[NSObject class]];
+        assertThatBool([module hasBindingForClass:[NSObject class]], equalToBool(YES));
+        [module unbindClass:[NSObject class]];
+        assertThatBool([module hasBindingForClass:[NSObject class]], equalToBool(NO));
+    });
+
+    it(@"supports protocol unbinding", ^{
+        id instance = [[NSObject alloc] init];
+        [module bind:instance toProtocol:@protocol(NSObject)];
+        assertThatBool([module hasBindingForProtocol:@protocol(NSObject)], equalToBool(YES));
+        [module unbindProtocol:@protocol(NSObject)];
+        assertThatBool([module hasBindingForProtocol:@protocol(NSObject)], equalToBool(NO));
+    });
+});
+
 SPEC_END


### PR DESCRIPTION
A very simple feature, yet I couldn't find any way to do it. When inheriting from another module and overriding `configure` I needed to unregister previously registered classes and protocols.

Please let me know if there is a better way to do it (the point is to inherit from an existing module so I won't have to write all binding again).

``` objective-c
[module unbindProtocol:@protocol(NSObject)];
[module unbindClass:[NSObject class]];
```
