### PR TITLE
Expose an injector's modules

### DIFF
--- a/Source/JSObjectionInjector.h
+++ b/Source/JSObjectionInjector.h
@@ -23,4 +23,5 @@
 - (id)withoutModuleCollection:(NSArray *)moduleClasses;
 - (void)injectDependencies:(id)object;
 - (id)objectForKeyedSubscript: (id)key;
+- (NSArray *)modules;
 @end

--- a/Source/JSObjectionInjector.m
+++ b/Source/JSObjectionInjector.m
@@ -192,6 +192,10 @@
     JSObjectionUtils.injectDependenciesIntoProperties(self, [object class], object);
 }
 
+- (NSArray *)modules {
+    return [_modules copy];
+}
+
 #pragma mark - Private
 
 - (void)initializeEagerSingletons {


### PR DESCRIPTION
Related to https://github.com/atomicobject/objection/issues/76

I want to be able to write functional tests which use objection to create an object graph. Some objects in that graph are registered as singletons. In between tests I want to create a new injector with the same module configuration but without inheriting the same global context so that I reset the state of the injector for each test.

By exposing the modules of the current injector I can write a test observer:

```
- (void)testCaseDidStart:(XCTestRun *)testRun {
    NSArray *modules = [[JSObjection defaultInjector] modules];
    JSObjectionInjector *injector = [JSObjection createInjectorWithModulesArray:modules];
    [JSObjection setDefaultInjector:injector];
    [super testCaseDidStart:testRun];
}
```

Which can recreate injectors without needing to know how Objection modules are configured in the application under test.
