### PR TITLE
fix crash while injecting property that implements a protocol

### DIFF
--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -34,6 +34,10 @@ static JSObjectionPropertyInfo FindClassOrProtocolForProperty(objc_property_t pr
         classOrProtocol = objc_getProtocol([classOrProtocolName UTF8String]);
         propertyInfo.type = JSObjectionTypeProtocol;
     } else {
+        if ([classOrProtocolName hasSuffix:@">"]) {
+            classOrProtocolName = [classOrProtocolName substringToIndex:[classOrProtocolName rangeOfString:@"<"].location];
+        }
+        
         classOrProtocol = NSClassFromString(classOrProtocolName);
         propertyInfo.type = JSObjectionTypeClass;
     }


### PR DESCRIPTION
This fixes the crash while injecting a property that implements a protocol, e.g.

```
@interface User()
@property (nonatomic, strong) Business<Ignore> *business;
@end

```