### PR TITLE
Add support for init args which are injected by Objection.

### DIFF
--- a/Source/JSObjectionEntry.h
+++ b/Source/JSObjectionEntry.h
@@ -12,7 +12,7 @@ typedef enum {
 @protocol JSObjectionEntry<NSObject>
 @property (nonatomic, readonly) JSObjectionScope lifeCycle;
 @property (nonatomic, assign) JSObjectionInjector *injector;
-- (id)extractObject:(NSArray *)arguments;
+- (id)extractObject:(NSArray *)arguments context:(NSDictionary *) context;
 + (id)entryWithEntry:(JSObjectionEntry *)entry;
 @end
 

--- a/Source/JSObjectionInjector.m
+++ b/Source/JSObjectionInjector.m
@@ -109,7 +109,7 @@
         }
         
         if (classOrProtocol && injectorEntry) {
-            return [injectorEntry extractObject:argumentList];
+            return [injectorEntry extractObject:argumentList context:_context];
         }
         
         return nil;

--- a/Source/JSObjectionInjectorEntry.m
+++ b/Source/JSObjectionInjectorEntry.m
@@ -4,7 +4,7 @@
 #import "NSObject+Objection.h"
 
 @interface JSObjectionInjectorEntry()
-- (id)buildObject:(NSArray *)arguments;
+- (id)buildObject:(NSArray *)arguments context:(NSDictionary *) context;
 - (id)argumentsForObject:(NSArray *)givenArguments;
 - (SEL)initializerForObject;
 @end
@@ -28,9 +28,9 @@
   return self;
 }
 
-- (id)extractObject:(NSArray *)arguments {
+- (id)extractObject:(NSArray *)arguments context:(NSDictionary *) context {
   if (self.lifeCycle == JSObjectionScopeNormal || !_storageCache) {
-      return [self buildObject:arguments];  
+      return [self buildObject:arguments context:context];
   }
   
   return _storageCache;
@@ -45,11 +45,14 @@
 #pragma mark -
 #pragma mark Private Methods
 
-- (id)buildObject:(NSArray *)arguments {
+- (id)buildObject:(NSArray *)arguments context:(NSDictionary *) context {
     
     id objectUnderConstruction = nil;
     if ([self.classEntry respondsToSelector:@selector(objectionInitializer)]) {
-        objectUnderConstruction = JSObjectionUtils.buildObjectWithInitializer(self.classEntry, [self initializerForObject], [self argumentsForObject:arguments]);
+        objectUnderConstruction = JSObjectionUtils.buildObjectWithInitializer(self.classEntry,
+                                                                              [self initializerForObject],
+                                                                              [self argumentsForObject:arguments],
+                                                                              context);
     } else {
         objectUnderConstruction = [[self.classEntry alloc] init];
     }

--- a/Source/JSObjectionUtils.h
+++ b/Source/JSObjectionUtils.h
@@ -26,6 +26,6 @@ extern const struct JSObjectionUtils {
     NSSet* (*buildDependenciesForClass)(Class klass, NSSet *requirements);
     NSDictionary* (*buildInitializer)(SEL selector, NSArray *arguments);
     NSArray* (*transformVariadicArgsToArray)(va_list va_arguments);
-    id (*buildObjectWithInitializer)(Class klass, SEL initializer, NSArray *arguments);
+    id (*buildObjectWithInitializer)(Class klass, SEL initializer, NSArray *arguments, NSDictionary *context);
     void (*injectDependenciesIntoProperties)(JSObjectionInjector *injector, Class klass, id object);
 } JSObjectionUtils;


### PR DESCRIPTION
The goal of this commit was to add the ability to automatically obtain initWith* args from Objection. The change updates the code to do several things:

 * Passes the Objection context through to the code that instantiates objects via their initWith methods.
 * When adding arguments to the initWith* NSInvocation, each argument is checked. If it's a NSString then it's looked up in the context.
 * If the key finds an object created by Objection, then that object is set as the invocation argument. 

This means that code like the following will work:

    objection_initializer(initWithComms: @"Comms")
    -(instancetype) initWithComms:(Comms *) commsX {
        self = [super init];
        if (self) {
        }
        return self;
    }
 
With Objection locating the commsX argument by looking up the key 'Comms' in the Objection context. This should also work with the standard method of parsing default args. Assuming that the value of those args do not match the name of an Object that Objection is managing.

