### PR TITLE
Fix up objection so there are no warnings about unknown selectors

### DIFF
--- a/Source/JSObjectionInjector.h
+++ b/Source/JSObjectionInjector.h
@@ -1,6 +1,14 @@
 #import <Foundation/Foundation.h>
 #import "JSObjectionModule.h"
 
+@protocol JSObjectionInjectorSelectors
+
+@optional
++ (NSSet *)objectionRequires;
++ (NSDictionary *)objectionRequiresNames;
+
+@end
+
 @interface JSObjectionInjector : NSObject 
 
 - (instancetype)initWithContext:(NSDictionary *)theGlobalContext;

--- a/Source/JSObjectionInjectorEntry.h
+++ b/Source/JSObjectionInjectorEntry.h
@@ -1,6 +1,13 @@
 #import <Foundation/Foundation.h>
 #import "JSObjectionEntry.h"
 
+@protocol JSObjectionInjectorEntrySelectors
+
+@optional
++ (id)objectionInitializer;
+
+@end
+
 @interface JSObjectionInjectorEntry : JSObjectionEntry
 
 @property (nonatomic, readonly) Class classEntry;

--- a/Source/JSObjectionInjectorEntry.m
+++ b/Source/JSObjectionInjectorEntry.m
@@ -73,11 +73,11 @@
 }
 
 - (SEL)initializerForObject {
-    return NSSelectorFromString([[self.classEntry performSelector:@selector(objectionInitializer)] objectForKey:JSObjectionInitializerKey]);
+    return NSSelectorFromString([[self.classEntry objectionInitializer] objectForKey:JSObjectionInitializerKey]);
 }
 
 - (NSArray *)argumentsForObject:(NSArray *)givenArguments {
-    return givenArguments.count > 0 ? givenArguments : [[self.classEntry performSelector:@selector(objectionInitializer)] objectForKey:JSObjectionDefaultArgumentsKey];
+    return givenArguments.count > 0 ? givenArguments : [[self.classEntry objectionInitializer] objectForKey:JSObjectionDefaultArgumentsKey];
 }
 
 

--- a/Source/JSObjectionUtils.m
+++ b/Source/JSObjectionUtils.m
@@ -50,7 +50,7 @@ static JSObjectionPropertyInfo FindClassOrProtocolForProperty(objc_property_t pr
 static NSSet* BuildDependenciesForClass(Class klass, NSSet *requirements) {
     Class superClass = class_getSuperclass([klass class]);
     if([superClass respondsToSelector:@selector(objectionRequires)]) {
-        NSSet *parentsRequirements = [superClass performSelector:@selector(objectionRequires)];
+        NSSet *parentsRequirements = [superClass objectionRequires];
         NSMutableSet *dependencies = [NSMutableSet setWithSet:parentsRequirements];
         [dependencies unionSet:requirements];
         requirements = dependencies;
@@ -61,7 +61,7 @@ static NSSet* BuildDependenciesForClass(Class klass, NSSet *requirements) {
 static NSDictionary* BuildNamedDependenciesForClass(Class klass, NSDictionary *namedRequirements) {
     Class superClass = class_getSuperclass([klass class]);
     if([superClass respondsToSelector:@selector(objectionRequiresNames)]) {
-       NSDictionary *parentsNamedRequirements = [superClass performSelector:@selector(objectionRequiresNames)];
+       NSDictionary *parentsNamedRequirements = [superClass objectionRequiresNames];
        NSMutableDictionary *namedDependencies = [NSMutableDictionary dictionaryWithDictionary:parentsNamedRequirements];
        [namedDependencies addEntriesFromDictionary:namedRequirements];
        namedRequirements = namedDependencies;
@@ -146,7 +146,7 @@ static void _validateObjectReturnedFromInjector(id *theObject, JSObjectionProper
 
 static void InjectDependenciesIntoProperties(JSObjectionInjector *injector, Class klass, id object) {
     if ([klass respondsToSelector:@selector(objectionRequires)]) {
-        NSSet *properties = [klass performSelector:@selector(objectionRequires)];
+        NSSet *properties = [klass objectionRequires];
         NSMutableDictionary *propertiesDictionary = [NSMutableDictionary dictionaryWithCapacity:properties.count];
         for (NSString *propertyName in properties) {
             JSObjectionPropertyInfo propertyInfo;
@@ -161,7 +161,7 @@ static void InjectDependenciesIntoProperties(JSObjectionInjector *injector, Clas
     }
 
     if ([klass respondsToSelector:@selector(objectionRequiresNames)]) {
-        NSDictionary *namedProperties = [klass performSelector:@selector(objectionRequiresNames)];
+        NSDictionary *namedProperties = [klass objectionRequiresNames];
         NSMutableDictionary *propertiesDictionary = [NSMutableDictionary dictionaryWithCapacity:namedProperties.count];
         for (NSString *namedPropertyKey in [namedProperties allKeys]) {
             NSString* propertyName = [namedProperties valueForKey:namedPropertyKey];
@@ -177,7 +177,7 @@ static void InjectDependenciesIntoProperties(JSObjectionInjector *injector, Clas
     }
 
     if ([object respondsToSelector:@selector(awakeFromObjection)]) {
-        [object performSelector:@selector(awakeFromObjection)];
+        [object awakeFromObjection];
     }
 }
 


### PR DESCRIPTION
When compiling objection we ran into warnings about unknown selectors. By declaring them in protocols the warning goes away. It also frees us up to do direct obj dispatch instead of calling through - performSelector:
