### PR TITLE
Fix of global context

### DIFF
--- a/Source/JSObjectionInjector.h
+++ b/Source/JSObjectionInjector.h
@@ -1,19 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "JSObjectionModule.h"
 
-@protocol JSObjectionInjectorSelectors
-
-@optional
-+ (NSSet *)objectionRequires;
-+ (NSDictionary *)objectionRequiresNames;
-
-@end
-
 @interface JSObjectionInjector : NSObject 
 
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext;
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext andModule:(JSObjectionModule *)theModule;
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext andModules:(NSArray *)theModules;
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext;
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext andModule:(JSObjectionModule *)theModule;
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext andModules:(NSArray *)theModules;
 - (id)getObject:(id)classOrProtocol;
 - (id)getObject:(id)classOrProtocol named:(NSString*)name;
 - (id)getObjectWithArgs:(id)classOrProtocol, ... NS_REQUIRES_NIL_TERMINATION;

--- a/Source/JSObjectionInjector.m
+++ b/Source/JSObjectionInjector.m
@@ -29,7 +29,7 @@
 @end
   
 @interface JSObjectionInjector() {
-  NSDictionary *_globalContext;
+  NSMutableDictionary *_globalContext;
   NSMutableDictionary *_context;
   NSSet *_eagerSingletons;
   NSMutableArray *_modules;
@@ -43,7 +43,7 @@
 
 @implementation JSObjectionInjector
 
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext {
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext {
     if ((self = [super init])) {
         _globalContext = theGlobalContext;
         _context = [[NSMutableDictionary alloc] init];
@@ -55,7 +55,7 @@
     return self;
 }
 
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext andModule:(JSObjectionModule *)theModule {
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext andModule:(JSObjectionModule *)theModule {
     if ((self = [self initWithContext:theGlobalContext])) {
         [self configureModule:theModule];
         [self initializeEagerSingletons];
@@ -63,7 +63,7 @@
     return self;
 }
 
-- (instancetype)initWithContext:(NSDictionary *)theGlobalContext andModules:(NSArray *)theModules {
+- (instancetype)initWithContext:(NSMutableDictionary *)theGlobalContext andModules:(NSArray *)theModules {
     if ((self = [self initWithContext:theGlobalContext])) {
         for (JSObjectionModule *module in theModules) {
             [self configureModule:module];      
@@ -261,6 +261,7 @@
     NSSet *mergedSet = [module.eagerSingletons setByAddingObjectsFromSet:_eagerSingletons];
     _eagerSingletons = mergedSet;
     [_context addEntriesFromDictionary:module.bindings];
+	[_globalContext addEntriesFromDictionary:_context];
 }
 
 - (void)configureDefaultModule {


### PR DESCRIPTION
I've discovered that this feature was partially implemented.
As the result, bindings from one injector was not available to the others.

My problem explained here: https://stackoverflow.com/questions/45587406/jsobjectionscopesingleton-is-partially-broken-in-objection-framework?noredirect=1#comment78133843_45587406

With my fixes the global context has bindings from any of created injectors.